### PR TITLE
🔨 Install yarn before attempting to use it

### DIFF
--- a/hooks/lib/run.bash
+++ b/hooks/lib/run.bash
@@ -31,6 +31,15 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 nvm install && nvm use
 
+# Install yarn
+if command -v yarn &> /dev/null
+then
+    echo -n "yarn "
+    yarn --version
+else
+    npm install --global yarn
+fi
+
 # Ensure typescript has been built
 yarn install
 yarn build


### PR DESCRIPTION
Since we're using this plugin from source, the Typescript code needs to be compiled using `yarn`. The `run.bash` script already has logic to bootstrap `nvm` to set up the node toolchain, but it assumes that `yarn` will be found on the `PATH`.

This PR adds a check to ensure `yarn` is found and falls back to installing it through `npm` if not.

Tested this new runner in PR getditto/ditto#15844
https://buildkite.com/dittolive-incorporated/ditto/builds/73870#0194bae4-75c4-42c8-bcd3-39d31d252004/27-40